### PR TITLE
Fix invalid iovec array in fd_write and add stdout test

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -518,8 +518,7 @@ export class Module {
 					const data_len = view.getUint32(iovs_ptr, true);
 					iovs_ptr += 4;
 
-					const data = new Uint8Array(this.memory.buffer);
-					nwritten += entry.handle.writeSync(data);
+					nwritten += entry.handle.writeSync(new Uint8Array(this.memory.buffer, data_ptr, data_len));
 				}
 
 				view.setUint32(nwritten_out, nwritten, true);

--- a/testdata/c/stdout.c
+++ b/testdata/c/stdout.c
@@ -1,0 +1,11 @@
+// { "stdout": "Hello, world!" }
+
+#include <stdio.h>
+
+int main(void) {
+	if (fputs("Hello, world!", stdout) == 0) {
+		return ferror(stdout);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
So fd_write is just completely messed up because for some reason; I read the offsets and lengths from the iovec array but never actually used them when calling write on the resource which in turn lead to calls blowing up in a fantastic manner.

This fixes that and adds a test for stdout to ensure that `fd_write` **actually** works.