### PR TITLE
Fix expected stderr output assertion and add stderr test

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -59,7 +59,7 @@ for await (const entry of Deno.readDir("testdata/c")) {
 
 		if (moduleProcess.stderr) {
 			const actual = new TextDecoder().decode(await Deno.readAll(moduleProcess.stderr));
-			const expected = moduleOptions.stderr ? moduleOptions.stdout : "";
+			const expected = moduleOptions.stderr ? moduleOptions.stderr : "";
 
 			assertEquals(actual, expected);
 

--- a/testdata/c/stderr.c
+++ b/testdata/c/stderr.c
@@ -1,0 +1,11 @@
+// { "stderr": "Hello, world!" }
+
+#include <stdio.h>
+
+int main(void) {
+	if (fputs("Hello, world!", stderr) == 0) {
+		return ferror(stderr);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
The test runner currently asserting that `actualStderr == expectedStdout` which is obviously wrong; a case of not doing a global replace with `s/stderr/stdout` and no tests to catch it.

This fixes that and adds a test to check that stdout is yielding the correct output.