### PR TITLE
Add support for pre-opening directories

### DIFF
--- a/testdata/c/mkdir.c
+++ b/testdata/c/mkdir.c
@@ -1,0 +1,10 @@
+#include <errno.h>
+#include <sys/stat.h>
+
+int main(void) {
+	if (mkdir("/tmp/foo", 0700) != 0) {
+		return errno;
+	}
+
+	return 0;
+}

--- a/testdata/c/rmdir.c
+++ b/testdata/c/rmdir.c
@@ -1,0 +1,10 @@
+#include <errno.h>
+#include <unistd.h>
+
+int main(void) {
+	if (rmdir("/tmp") != 0) {
+		return errno;
+	}
+
+	return 0;
+}

--- a/testdata/runner.ts
+++ b/testdata/runner.ts
@@ -6,6 +6,9 @@ const mod = await WebAssembly.compile(bin);
 const wasi = new WASI({
 	env: Deno.env.toObject(),
 	args: Deno.args.slice(1),
+	preopens: {
+		"/tmp": Deno.makeTempDirSync(),
+	},
 });
 
 const instance = new WebAssembly.Instance(mod, {


### PR DESCRIPTION
This adds support for pre-opened mapped directories via the module constructor option, implements `fd_prestat_get` and `fd_prestat_dir_dir` along with a couple of tests to ensure that it works as intended.