### PR TITLE
Add support for opening files

### DIFF
--- a/testdata/c/fwrite.c
+++ b/testdata/c/fwrite.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+	FILE* file = fopen("/tmp/output.txt", "w");
+	assert(file != NULL);
+
+	char data[] = "Hello, output.txt!";
+	int nwritten = fwrite(data, sizeof(char), sizeof(data), file);
+	assert(nwritten == sizeof(data));
+
+	assert(ferror(file) == 0);
+	assert(fclose(file) == 0);
+}


### PR DESCRIPTION
This implements `path_open` as a direct mapping to `Deno.open` which
comes with the caveat that only files work consistently across platforms
so opening directories is not considered supported at this time.

A simple test case to ensure that calls to `fopen` and `fwrite` succeed is also added.
