### PR TITLE
Implement `fd_seek` and fd_tell

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -571,6 +571,20 @@ export class Module {
 			},
 
 			fd_tell: (fd : number, offset_out : number) : number => {
+				const entry = this.fds[fd];
+				if (!entry) {
+					return ERRNO_BADF;
+				}
+
+				const view = new DataView(this.memory.buffer);
+
+				try {
+					const offset = entry.handle.seekSync(0, Deno.SeekMode.Current);
+					view.setBigUint64(offset_out, offset, true);
+				} catch (err) {
+					return ERRNO_INVAL;
+				}
+
 				return ERRNO_NOSYS;
 			},
 

--- a/testdata/c/fseek.c
+++ b/testdata/c/fseek.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+	FILE *file = fopen("/tmp/output.txt", "w");
+	assert(file != NULL);
+
+	char data[32] = { 0 };
+	assert(fwrite(data, sizeof(char), sizeof(data), file) == 32);
+
+	assert(fseek (file, 16, SEEK_SET) == 0);
+	assert(ftell(file) == 16);
+
+	assert(fseek (file, 16, SEEK_CUR) == 0);
+	assert(ftell(file) == 32);
+
+	assert(fseek (file, 0, SEEK_END) == 0);
+	assert(ftell(file) == 32);
+
+	assert(fclose(file) == 0);
+}


### PR DESCRIPTION
This implements `fd_seek` and `fd_tell` as an indirect mapping to `Deno.seekSync`.

There is one caveat here; `Deno.seekSync` is incapable of handling big integers so
offsets larger than `Number.MAX_INTEGER_SIZE` are truncated.