### PR TITLE
Run tests with unstable features enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
       run: bash .github/scripts/setup_deno.sh
 
     - name: Run tests
-      run: deno test -A
+      run: deno test --unstable -A

--- a/test.ts
+++ b/test.ts
@@ -53,7 +53,7 @@ for await (const entry of Deno.readDir("testdata/c")) {
 		compilerProcess.close()
 
 		const moduleProcess = await Deno.run({
-			cmd: ["deno", "run", "--v8-flags=--experimental-wasm-bigint", "-q", "-A", "test.ts", modulePath, ...(moduleOptions.args ? moduleOptions.args : [])],
+			cmd: ["deno", "run", "--unstable", "--v8-flags=--experimental-wasm-bigint", "-q", "-A", "test.ts", modulePath, ...(moduleOptions.args ? moduleOptions.args : [])],
 			env: moduleOptions.env ? moduleOptions.env : {},
 			stdin: "piped",
 			stdout: "piped",


### PR DESCRIPTION
Some syscalls are going to have to rely on unstable features like `Deno.utimeSync` is currently marked as unstable.

This adds the unstable flag when invoking the test runner to ensure they'll run without complaint.