### PR TITLE
Implement `path_rename`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -885,7 +885,29 @@ export class Module {
 			},
 
 			path_rename: (fd : number, old_path_ptr : number, old_path_len : number, new_fd : number, new_path_ptr : number, new_path_len : number) : number => {
-				return ERRNO_NOSYS;
+				const old_entry = this.fds[fd];
+				const new_entry = this.fds[new_fd];
+				if (!old_entry || !new_entry) {
+					return ERRNO_BADF;
+				}
+
+				if (!old_entry.path || !new_entry.path) {
+					return ERRNO_INVAL;
+				}
+
+				const text = new TextDecoder();
+				const old_data = new Uint8Array(this.memory.buffer, old_path_ptr, old_path_len);
+				const old_path = resolve(old_entry.path, text.decode(old_data));
+				const new_data = new Uint8Array(this.memory.buffer, new_path_ptr, new_path_len);
+				const new_path = resolve(new_entry.path, text.decode(new_data));
+
+				try {
+					Deno.renameSync(old_path, new_path);
+				} catch (err) {
+					return errno(err);
+				}
+
+				return ERRNO_SUCCESS;
 			},
 
 			path_symlink: (old_path_ptr : number, old_path_len : number, fd : number, new_path_ptr : number, new_path_len : number) : number => {

--- a/testdata/c/rename.c
+++ b/testdata/c/rename.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+	char oldname[] = "/tmp/oldfile";
+	char newname[] = "/tmp/newfile";
+
+	FILE *oldfile = fopen(oldname, "w");
+	assert(oldfile != NULL);
+	assert(fclose(oldfile) == 0);
+
+	assert(rename(oldname, newname) == 0);
+
+	FILE *newfile = fopen(newname, "r");
+	assert(newfile != NULL);
+	assert(fclose(newfile) == 0);
+
+	return 0;
+}


### PR DESCRIPTION
This implements `path_rename` as a mapping to `Deno.renameSync` and adds a test to ensure that calls to `rename` succeed.