### PR TITLE
Implement `path_unlink_file`

### DIFF
--- a/testdata/c/unlink.c
+++ b/testdata/c/unlink.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+#include <unistd.h>
+
+int main(void) {
+	assert(unlink("/tmp") == 0);
+
+	return 0;
+}


### PR DESCRIPTION
This implements `path_unlink_file` as a direct mapping to `Deno.remove` and adds a test to ensure that calls to `unlink` succeed.
