### PR TITLE
Set strategy fail-fast to false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 


### PR DESCRIPTION
Set strategy fail-fast to false to keep tests running on other operating
systems even if one operating system fails.