### PR TITLE
Remove stray call to `console.error`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -608,7 +608,6 @@ export class Module {
 					const newoffset = entry.handle.seekSync(Number(offset), whence);
 					view.setBigUint64(newoffset_out, BigInt(newoffset), true);
 				} catch (err) {
-					console.error(err);
 					return ERRNO_INVAL;
 				}
 


### PR DESCRIPTION
There's a stray call to `console.error` in `fd_seek`, most likely left over from debugging a test.

This removes the offending call.