### PR TITLE
Use deno v1.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up deno
       uses: denolib/setup-deno@master
       with:
-        deno-version: 1
+        deno-version: v1.x
 
     - name: Run tests
       run: deno test -A


### PR DESCRIPTION
This bumps the deno version used when running tests from v1.0 to v1.x.