### PR TITLE
Use cargo to install deno

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,7 @@ jobs:
         echo "::add-path::c:/wasi-sdk/bin"
 
     - name: Set up deno
-      uses: denolib/setup-deno@master
-      with:
-        deno-version: v1.x
+      run: cargo install deno
 
     - name: Run tests
       run: deno test -A


### PR DESCRIPTION
This replaces the seemingly broken setup-deno action with a simple run command that invokes `cargo install deno`.