### PR TITLE
Implement `path_symlink` and add a test case for `symlink(2)`

### DIFF
--- a/testdata/c/symlink.c
+++ b/testdata/c/symlink.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <unistd.h>
+
+int main(void) {
+	const char* filepath = "./testdata/fixture/directory/file";
+	const char* linkpath = "/fixture/directory/file_symlink";
+
+	assert(symlink(filepath, linkpath) == 0);
+	assert(unlink(linkpath) == 0);
+}


### PR DESCRIPTION
This implements `path_symlink` as a mapping to `Deno.symlinkSync and adds a test case to ensure that calls to `symlink(2)` succeed.