### PR TITLE
Mark `path_link` and `path_symlink` as complete and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is a work in progress so if a function isn't implemented, hit refresh.
 | `path_rename`             | &check; |                                                                                        |
 | `path_symlink`            | &check; |                                                                                        |
 | `path_unlink_file`        | &check; |                                                                                        |
-| `poll_one_off`            |         |                                                                                        |
+| `poll_oneoff`             |         |                                                                                        |
 | `proc_exit`               | &check; |                                                                                        |
 | `proc_raise`              |         |                                                                                        |
 | `sched_yield`             |         |                                                                                        |

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ This is a work in progress so if a function isn't implemented, hit refresh.
 | `path_create_directory`   | &check; |                                                                                        |
 | `path_filestat_get`       | &check; |                                                                                        |
 | `path_filestat_set_times` | &check; |                                                                                        |
-| `path_link`               |         |                                                                                        |
+| `path_link`               | &check; |                                                                                        |
 | `path_open`               | &check; | Opening directories is not portable                                                    |
 | `path_readlink`           |         |                                                                                        |
 | `path_remove_directory`   | &check; |                                                                                        |
 | `path_rename`             | &check; |                                                                                        |
-| `path_symlink`            |         |                                                                                        |
+| `path_symlink`            | &check; |                                                                                        |
 | `path_unlink_file`        | &check; |                                                                                        |
 | `poll_one_off`            |         |                                                                                        |
 | `proc_exit`               | &check; |                                                                                        |


### PR DESCRIPTION
This marks `path_link` and `path_symlink` as complete in the implementation status table.
Also fixes a minor typo in the implementation status table where `poll_oneoff` was listed as `poll_one_off`