### PR TITLE
Stub `sched_yield`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1066,7 +1066,7 @@ export class Module {
 			},
 
 			sched_yield: () : number => {
-				return ERRNO_NOSYS;
+				return ERRNO_SUCCESS;
 			},
 
 			random_get: (buf_ptr : number, buf_len : number) : number => {


### PR DESCRIPTION
This stubs out `sched_yield` as a no-op which is enough to be conformant.